### PR TITLE
housekeeping

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,11 @@
-{ config, lib, pkgs, inputs, quasar, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  quasar,
+  ...
+}:
 
 {
 
@@ -48,12 +55,14 @@
   networking.hostName = quasar.hostname;
 
   # Select kernel
-  boot.kernelPackages = {
-    "zen" = pkgs.linuxPackages_zen;
-    "latest" = pkgs.linuxPackages_latest;
-    "hardened" = pkgs.linuxPackages_latest_hardened;
-    "libre" = pkgs.linuxPackages_latest-libre;
-  }.${quasar.kernel};
+  boot.kernelPackages =
+    {
+      "zen" = pkgs.linuxPackages_zen;
+      "latest" = pkgs.linuxPackages_latest;
+      "hardened" = pkgs.linuxPackages_latest_hardened;
+      "libre" = pkgs.linuxPackages_latest-libre;
+    }
+    .${quasar.kernel};
 
   # Enable networking
   networking.networkmanager.enable = true;
@@ -82,7 +91,9 @@
   };
 
   # Faster boot times
-  systemd.services = { NetworkManager-wait-online.enable = false; };
+  systemd.services = {
+    NetworkManager-wait-online.enable = false;
+  };
 
   # Disable the X11 windowing system,
   # since Hyprland uses the more modern Wayland
@@ -133,17 +144,25 @@
   users.users.${quasar.user} = {
     isNormalUser = true;
     description = quasar.name;
-    extraGroups = [ "networkmanager" "wheel" ];
+    extraGroups = [
+      "networkmanager"
+      "wheel"
+    ];
     shell = pkgs.fish;
   };
 
   # More user configuration
   nix.settings = {
-    trusted-users = [ "root" quasar.user ];
-    experimental-features = [ "nix-command" "flakes" ];
+    trusted-users = [
+      "root"
+      quasar.user
+    ];
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
     substituters = [ "https://hyprland.cachix.org" ];
-    trusted-public-keys =
-      [ "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" ];
+    trusted-public-keys = [ "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" ];
   };
 
   # Allow unfree packages for proprietary driver support
@@ -151,8 +170,18 @@
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
-  environment.systemPackages = with pkgs;
-    [ micro curl bat gnumake clang gcc cachix gnupg ]
+  environment.systemPackages =
+    with pkgs;
+    [
+      micro
+      curl
+      bat
+      gnumake
+      clang
+      gcc
+      cachix
+      gnupg
+    ]
     ++ (quasar.systemPackages pkgs);
 
   # Git is an essential system package
@@ -207,23 +236,26 @@
   # Install and configure appropriate NVIDIA drivers
   # Do not attempt to disable unfree software packages if you enable this
   services.xserver.videoDrivers = [ "nvidia" ];
-  hardware.nvidia = if quasar.graphics.nvidia.enabled then {
-    package = config.boot.kernelPackages.nvidiaPackages.stable;
-    modesetting.enable = true;
-    powerManagement.enable = true;
-    powerManagement.finegrained = true;
-    open = false;
-    nvidiaSettings = true;
-    prime = {
-      offload = {
-        enable = true;
-        enableOffloadCmd = true;
-      };
-      intelBusId = quasar.graphics.nvidia.intelBusId;
-      nvidiaBusId = quasar.graphics.nvidia.nvidiaBusId;
-    };
-  } else
-    null;
+  hardware.nvidia =
+    if quasar.graphics.nvidia.enabled then
+      {
+        package = config.boot.kernelPackages.nvidiaPackages.stable;
+        modesetting.enable = true;
+        powerManagement.enable = true;
+        powerManagement.finegrained = true;
+        open = false;
+        nvidiaSettings = true;
+        prime = {
+          offload = {
+            enable = true;
+            enableOffloadCmd = true;
+          };
+          intelBusId = quasar.graphics.nvidia.intelBusId;
+          nvidiaBusId = quasar.graphics.nvidia.nvidiaBusId;
+        };
+      }
+    else
+      null;
 
   fonts = {
     enableDefaultPackages = true;

--- a/flake.nix
+++ b/flake.nix
@@ -55,42 +55,78 @@
   };
 
   outputs =
-    { self, nixpkgs, nixpkgs-upstream, home-manager, lanzaboote, ... }@inputs: {
-      make = { hostname, user, name, git, hardware, system ? "x86_64-linux"
-        , kernel ? "zen", secureboot ? { enabled = true; }
-        , stateVersion ? "24.05", systemPackages, homePackages, autoLogin ? true
-        , ssh ? { enabled = false; }, locale ? "en_US.UTF-8"
-        , hyprland ? { mod = "SUPER"; }, graphics ? {
-          opengl = true;
-          nvidia = {
+    {
+      self,
+      nixpkgs,
+      nixpkgs-upstream,
+      home-manager,
+      lanzaboote,
+      ...
+    }@inputs:
+    {
+      make =
+        {
+          hostname,
+          user,
+          name,
+          git,
+          hardware,
+          system ? "x86_64-linux",
+          kernel ? "zen",
+          secureboot ? {
             enabled = true;
-            intelBusId = null;
-            nvidiaBusId = null;
-          };
-        }, audio ? { jack = false; }, overrides ? [ ], homeOverrides ? [ ], ...
+          },
+          stateVersion ? "24.05",
+          systemPackages,
+          homePackages,
+          autoLogin ? true,
+          ssh ? {
+            enabled = false;
+          },
+          locale ? "en_US.UTF-8",
+          hyprland ? {
+            mod = "SUPER";
+          },
+          graphics ? {
+            opengl = true;
+            nvidia = {
+              enabled = true;
+              intelBusId = null;
+              nvidiaBusId = null;
+            };
+          },
+          audio ? {
+            jack = false;
+          },
+          overrides ? [ ],
+          homeOverrides ? [ ],
+          ...
         }@quasar:
         let
           # Secure boot configuration
           secureBoot = [
             lanzaboote.nixosModules.lanzaboote
 
-            ({ pkgs, lib, ... }: {
-              environment.systemPackages = [
-                # For debugging and troubleshooting secure boot
-                pkgs.sbctl
-              ];
+            (
+              { pkgs, lib, ... }:
+              {
+                environment.systemPackages = [
+                  # For debugging and troubleshooting secure boot
+                  pkgs.sbctl
+                ];
 
-              # Lanzaboote currently replaces the systemd-boot module.
-              # This setting is usually set to true in configuration.nix,
-              # generated at installation time.
-              # So we force it to false for now.
-              boot.loader.systemd-boot.enable = lib.mkForce false;
+                # Lanzaboote currently replaces the systemd-boot module.
+                # This setting is usually set to true in configuration.nix,
+                # generated at installation time.
+                # So we force it to false for now.
+                boot.loader.systemd-boot.enable = lib.mkForce false;
 
-              boot.lanzaboote = {
-                enable = true;
-                pkiBundle = "/etc/secureboot";
-              };
-            })
+                boot.lanzaboote = {
+                  enable = true;
+                  pkiBundle = "/etc/secureboot";
+                };
+              }
+            )
           ];
 
           # Modules without conditional add-ons
@@ -113,19 +149,16 @@
               home-manager.users.${user} = {
                 # Primary user Home Manager configuration module
                 imports = [
-                  (import ./home.nix quasar
-                    nixpkgs-upstream.legacyPackages.${system}.hyprlandPlugins)
+                  (import ./home.nix quasar nixpkgs-upstream.legacyPackages.${system}.hyprlandPlugins)
                 ] ++ homeOverrides;
               };
             }
           ];
 
           # Modules with conditional add-ons
-          modules = if secureboot.enabled then
-            baseModules ++ secureBoot
-          else
-            baseModules;
-        in {
+          modules = if secureboot.enabled then baseModules ++ secureBoot else baseModules;
+        in
+        {
           system = nixpkgs.lib.nixosSystem {
             # Forward external configurations to declared modules
             specialArgs = {
@@ -141,7 +174,6 @@
           };
         };
 
-      formatter.x86_64-linux =
-        nixpkgs.legacyPackages.x86_64-linux.nixfmt-classic;
+      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
     };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,5 +1,10 @@
 quasar: hyprPlugins:
-{ config, pkgs, inputs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 
 {
 
@@ -41,7 +46,8 @@ quasar: hyprPlugins:
   # '';
 
   # Packages that should be installed to the user profile.
-  home.packages = with pkgs;
+  home.packages =
+    with pkgs;
     [
       # essential
       brave
@@ -83,7 +89,8 @@ quasar: hyprPlugins:
       lazygit
       micro
       zed-editor
-    ] ++ (quasar.homePackages pkgs);
+    ]
+    ++ (quasar.homePackages pkgs);
 
   wayland.windowManager.hyprland = {
     enable = true;
@@ -99,7 +106,9 @@ quasar: hyprPlugins:
       size = "32x32";
     };
   };
-  services.easyeffects = { enable = true; };
+  services.easyeffects = {
+    enable = true;
+  };
 
   programs.gh.enable = true;
   programs.fzf.enable = true;
@@ -131,13 +140,12 @@ quasar: hyprPlugins:
 
   programs.git = {
     enable = true;
-    userName = if builtins.hasAttr "name" quasar.git then
-      quasar.git.name
-    else
-      quasar.name;
+    userName = if builtins.hasAttr "name" quasar.git then quasar.git.name else quasar.name;
     userEmail = quasar.git.email;
     delta.enable = true;
-    extraConfig = { init.defaultBranch = "main"; };
+    extraConfig = {
+      init.defaultBranch = "main";
+    };
   };
 
   programs.kitty = {
@@ -160,7 +168,9 @@ quasar: hyprPlugins:
       name = "Bibata-Modern-Classic";
       size = 26;
     };
-    iconTheme = { name = "Papirus-Dark"; };
+    iconTheme = {
+      name = "Papirus-Dark";
+    };
   };
 
   qt = {
@@ -175,12 +185,10 @@ quasar: hyprPlugins:
       theme=GraphiteNordDark
     '';
 
-    "Kvantum/GraphiteNord".source =
-      "${pkgs.graphite-kde-theme}/share/Kvantum/GraphiteNord";
+    "Kvantum/GraphiteNord".source = "${pkgs.graphite-kde-theme}/share/Kvantum/GraphiteNord";
   };
 
-  programs.chromium.commandLineArgs =
-    "--enable-features=UseOzonePlatform --ozone-platform=wayland";
+  programs.chromium.commandLineArgs = "--enable-features=UseOzonePlatform --ozone-platform=wayland";
 
   home.stateVersion = quasar.stateVersion;
   programs.home-manager.enable = true;

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -1,10 +1,12 @@
 quasar:
 let
   hyprland = quasar.hyprland;
-  default = mod: attr: fallback:
+  default =
+    mod: attr: fallback:
     if builtins.hasAttr attr mod then mod.${attr} else fallback;
   hypr = attr: fallback: default hyprland attr fallback;
-in {
+in
+{
 
   #  /*****                                                 /******   /****
   #  |*    |  |*   |    **     ****     **    *****        |*    |  /*    * 
@@ -19,7 +21,10 @@ in {
   # This is the default Hyrpland configuration that ships with QuasarOS.
   # It should be modified from the Quasar configuration, not here.
 
-  exec-once = [ "waybar" "swww-daemon; swww restore;" ];
+  exec-once = [
+    "waybar"
+    "swww-daemon; swww restore;"
+  ];
   "$mod" = hypr "mod" "SUPER";
   "$Left" = hypr "left" "Left";
   "$Right" = hypr "right" "Right";
@@ -110,13 +115,8 @@ in {
     "$mod+Shift, ${hypr "min" "S"}, movetoworkspacesilent, special"
 
     # Utilities
-    "$mod, ${
-      hypr "omni" "Space"
-    }, exec, pkill -x rofi || rofi -show drun" # Run rofi
-    ''
-      $mod, ${
-        hypr "screen" "P"
-      }, exec, grim -g "$(slurp)" - | swappy -f -'' # Screenshot
+    "$mod, ${hypr "omni" "Space"}, exec, pkill -x rofi || rofi -show drun" # Run rofi
+    ''$mod, ${hypr "screen" "P"}, exec, grim -g "$(slurp)" - | swappy -f -'' # Screenshot
     "$mod, ${hypr "menu" "Backspace"}, exec, wlogout" # Show power menu
   ];
   bindm = [
@@ -187,5 +187,7 @@ in {
       special = true;
     };
   };
-  misc = { force_default_wallpaper = 0; };
+  misc = {
+    force_default_wallpaper = 0;
+  };
 }

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -22,7 +22,6 @@ in
   # It should be modified from the Quasar configuration, not here.
 
   exec-once = [
-    "waybar"
     "swww-daemon; swww restore;"
   ];
   "$mod" = hypr "mod" "SUPER";


### PR DESCRIPTION
Greetings. This is your automated NixOS maintenance service. Thank you for choosing our services. This is a trial run, please considering purchasing a long-term subscription.

I'm sorry, as an AI language model, I am not able to solicit or collect payments in pull requests.

The default formatter has been changed to the new RFC styling, which is what is being used in upstream nixpkgs and the canonical style of Nix code. Additionally, `waybar` has been removed from Hyprland `exec-once` as it assumes the availability of a `waybar` executable on the system PATH which is not guaranteed. Instead, you should either leave waybar configuration entirely up to flake consumers, or add the following line in `home.nix`:

```
programs.waybar = {
  enable = true;
  systemd.enable = true;
};
```

This will start waybar as a `systemd` unit, which is more reliable than `exec-once`.