### PR TITLE
Fix hyprscroller

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,6 +372,22 @@
         "type": "github"
       }
     },
+    "hyprscroller-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746802628,
+        "narHash": "sha256-m9689UH+w8Z/qP/DKYtzQfIGfiE4jgBAfO+uH34cfNs=",
+        "owner": "cpiber",
+        "repo": "hyprscroller",
+        "rev": "de97924b6d1086d84939b6f6688637f7b21d8d80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cpiber",
+        "repo": "hyprscroller",
+        "type": "github"
+      }
+    },
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
@@ -539,6 +555,7 @@
       "inputs": {
         "gitbutler": "gitbutler",
         "home-manager": "home-manager",
+        "hyprscroller-src": "hyprscroller-src",
         "lanzaboote": "lanzaboote",
         "nixpkgs": "nixpkgs",
         "nixpkgs-upstream": "nixpkgs-upstream",

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
     # Enable pre-commit hooks on this repository
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
 
+    # Add maintained hyprscroller instance
     hyprscroller-src = {
       url = "github:cpiber/hyprscroller";
       flake = false;
@@ -94,13 +95,13 @@
     {
       self,
       nixpkgs,
-      nixpkgs-upstream,
       home-manager,
       zen-browser,
       gitbutler,
       # betterbird,
       lanzaboote,
       stylix,
+      hyprscroller-src,
       ...
     }@inputs:
     let
@@ -244,10 +245,7 @@
                       ];
                     in
                     [
-                      (import ./home.nix quasar utils upstream
-                        nixpkgs-upstream.legacyPackages.${quasar.system}.hyprlandPlugins
-                        pack
-                      )
+                      (import ./home.nix quasar utils upstream hyprscroller-src pack)
                     ]
                     ++ quasar.homeOverrides;
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,11 @@
 
     # Enable pre-commit hooks on this repository
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
+
+    hyprscroller-src = {
+      url = "github:cpiber/hyprscroller";
+      flake = false;
+    };
   };
 
   outputs =

--- a/home.nix
+++ b/home.nix
@@ -3,6 +3,7 @@ quasar: utils: _upstream: plugins: pack:
   pkgs,
   config,
   lib,
+  inputs,
   ...
 }:
 
@@ -105,16 +106,23 @@ quasar: utils: _upstream: plugins: pack:
   };
 
   # Hyprland user config
-  wayland.windowManager.hyprland = {
-    enable = true;
-    plugins = [ plugins.hyprscroller ];
-    settings = import ./modules/hyprland.nix (
-      quasar
-      // {
-        inherit config lib;
-      }
-    ) utils;
-  };
+  wayland.windowManager.hyprland =
+    let
+      hyprscroller = pkgs.callPackage ./pkgs/vendored/hyprscroller.nix {
+        src = inputs.hyprscroller-src;
+        version = inputs.hyprscroller-src.lastModified;
+      };
+    in
+    {
+      enable = true;
+      plugins = [ hyprscroller ];
+      settings = import ./modules/hyprland.nix (
+        quasar
+        // {
+          inherit config lib;
+        }
+      ) utils;
+    };
 
   # All services
   services = {

--- a/home.nix
+++ b/home.nix
@@ -1,9 +1,8 @@
-quasar: utils: _upstream: plugins: pack:
+quasar: utils: _upstream: hyprscroller-src: pack:
 {
   pkgs,
   config,
   lib,
-  inputs,
   ...
 }:
 
@@ -109,8 +108,8 @@ quasar: utils: _upstream: plugins: pack:
   wayland.windowManager.hyprland =
     let
       hyprscroller = pkgs.callPackage ./pkgs/vendored/hyprscroller.nix {
-        src = inputs.hyprscroller-src;
-        version = inputs.hyprscroller-src.lastModified;
+        src = hyprscroller-src;
+        version = hyprscroller-src.lastModified;
       };
     in
     {

--- a/home.nix
+++ b/home.nix
@@ -109,7 +109,7 @@ quasar: utils: _upstream: hyprscroller-src: pack:
     let
       hyprscroller = pkgs.callPackage ./pkgs/vendored/hyprscroller.nix {
         src = hyprscroller-src;
-        version = hyprscroller-src.lastModified;
+        version = builtins.toString hyprscroller-src.lastModified;
       };
     in
     {

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -55,6 +55,11 @@ in
     # recommended opacity toggle; see https://github.com/hyprwm/Hyprland/pull/7024
     "$mod, ${hypr "opaque" "O"}, exec, hyprctl setprop active opaque toggle"
 
+    # Hyprscroller
+    "$mod, ${hypr "view" "A"}, scroller:toggleoverview"
+    "$mod+Shift, K, scroller:cyclesize, +1"
+    "$mod+Shift, J, scroller:cyclesize, -1"
+
     # Hyprshot
     "$mod+Shift, ${hypr "window" "W"}, exec, hyprshot -m window --clipboard-only"
     "$mod+Alt, ${hypr "window" "W"}, exec, hyprshot -m window"
@@ -68,7 +73,7 @@ in
     "Ctrl+Alt, C, exec, hyprpicker | wl-copy"
 
     # Resizing
-    "$mod+Alt, 1, exec, hyprctl dispatch resizeactive exact 50% 89%"
+    "$mod+Alt, 1, exec, hyprctl dispatch resizeactive exact 50% 89% && hyprctl dispatch scroller:admitwindow && hyprctl dispatch scroller:expelwindow"
     "$mod+Alt, 2, resizeactive, exact 50% 47%"
     "$mod+Alt, 3, resizeactive, exact 50% 31%"
     "$mod+Alt, 4, resizeactive, exact 50% 23%"
@@ -76,10 +81,10 @@ in
     "$mod+Alt, 7, resizeactive, exact 50% 71%"
 
     # Move around
-    "$mod, H, movefocus, l"
-    "$mod, L, movefocus, r"
-    "$mod, K, movefocus, u"
-    "$mod, J, movefocus, d"
+    "$mod, H, scroller:movefocus, l"
+    "$mod, L, scroller:movefocus, r"
+    "$mod, K, scroller:movefocus, u"
+    "$mod, J, scroller:movefocus, d"
 
     # Change workspaces
     "$mod, 0, workspace, 10"
@@ -105,8 +110,12 @@ in
     "$mod+Shift, 0, movetoworkspace, 10"
 
     # Move windows around
-    "$mod+Shift, H, movewindow, l"
-    "$mod+Shift, L, movewindow, r"
+    "$mod+Shift, H, scroller:movewindow, l"
+    "$mod+Shift, H, scroller:alignwindow, l"
+    "$mod+Shift, L, scroller:movewindow, r"
+    "$mod+Shift, L, scroller:alignwindow, r"
+    "$mod, comma, scroller:admitwindow"
+    "$mod, period, scroller:expelwindow"
 
     # Workspace shortcuts
     "$mod+Ctrl+Shift, J, movetoworkspace, r+1"
@@ -184,7 +193,7 @@ in
       "col.active_border" = lib.mkForce "rgba(${colors.base0A}ff) rgba(${colors.base09}ff) 45deg";
       "col.inactive_border" = lib.mkForce "rgba(${colors.base01}cc) rgba(${colors.base02}cc) 45deg";
 
-      layout = "master";
+      layout = "scroller";
       resize_on_border = "true";
       allow_tearing = "false";
     };

--- a/pkgs/vendored/hyprscroller.nix
+++ b/pkgs/vendored/hyprscroller.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  hyprland,
+  pkg-config,
+  cmake,
+  src,
+  version,
+}:
+let
+  mkHyprlandPlugin =
+    hyprland:
+    args@{ pluginName, ... }:
+    hyprland.stdenv.mkDerivation (
+      args
+      // {
+        pname = "${pluginName}";
+        nativeBuildInputs = [ pkg-config ] ++ args.nativeBuildInputs or [ ];
+        buildInputs = [ hyprland ] ++ hyprland.buildInputs ++ (args.buildInputs or [ ]);
+        meta = args.meta // {
+          description = args.meta.description or "";
+          longDescription =
+            (args.meta.longDescription or "")
+            + "\n\nPlugins can be installed via a plugin entry in the Hyprland NixOS or Home Manager options.";
+        };
+      }
+    );
+in
+mkHyprlandPlugin hyprland {
+  inherit src version;
+  pluginName = "hyprscroller";
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv hyprscroller.so $out/lib/libhyprscroller.so
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/cpiber/hyprscroller";
+    description = "Hyprland layout plugin providing a scrolling layout like PaperWM";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ youwen5 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
# Fixes hyprscroller

The liminalOS Agency for International Development is pleased to announce that it has approved the appropriation of another aid package to alleviate the devastating effects of the deprecation of hyprscroller in third-world operating systems.

