### PR TITLE
fix: don't turn off monitor when docked

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -155,6 +155,10 @@
       autoLogin.user = if quasar.autoLogin then quasar.user else null;
     };
 
+    # Lid switch actions
+    logind.lidSwitch = "suspend";
+    logind.lidSwitchDocked = "ignore";
+
     # Enable CUPS to print documents
     printing.enable = false;
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -156,7 +156,7 @@
     };
 
     # Lid switch actions
-    logind.lidSwitch = "suspend";
+    logind.lidSwitch = "ignore";
     logind.lidSwitchDocked = "ignore";
 
     # Enable CUPS to print documents

--- a/home.nix
+++ b/home.nix
@@ -166,6 +166,10 @@ quasar: utils: _upstream: hyprland: hyprscroller: pack:
             timeout = 1800;
             on-timeout = "systemctl suspend";
           }
+          {
+            on-lid-close = "echo 'no naps allowed'";
+            on-lid-open = "hyprctl dispatch dpms on";
+          }
         ];
       };
     };

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -152,6 +152,16 @@ in
     "$mod, X, resizewindow"
   ];
 
+  # Switches (turn off laptop screen on lid close)
+  bindl = [
+    ", switch:on:Lid Switch, exec, hyprctl keyword monitor \"${
+      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+    }, disable\""
+    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
+      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+    }, enable\""
+  ];
+
   # Window rules
   layerrule = [ ];
   windowrulev2 = [


### PR DESCRIPTION
previously connecting the laptop to a monitor would not disable the lid switch sleep action