### PR TITLE
fix: never suspend, always turn off screen on lid switch

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -155,6 +155,11 @@
       autoLogin.user = if quasar.autoLogin then quasar.user else null;
     };
 
+    # Always ignore lid switch because logind cannot detect if docked
+    # Instead, we use a custom utility for power management (see `modules/hyprland.nix`)
+    logind.lidSwitch = "ignore";
+    logind.lidSwitchDocked = "ignore";
+
     # Enable CUPS to print documents
     printing.enable = false;
 

--- a/home.nix
+++ b/home.nix
@@ -65,6 +65,7 @@ quasar: utils: _upstream: hyprland: hyprscroller: pack:
         wlogout
         hyprland-qtutils
         wl-clipboard
+        wlr-randr
         rofi-wayland
         hyprshot
         clipse
@@ -116,7 +117,7 @@ quasar: utils: _upstream: hyprland: hyprscroller: pack:
       // {
         inherit config lib;
       }
-    ) utils;
+    ) utils pkgs.wlr-randr;
   };
 
   # All services

--- a/home.nix
+++ b/home.nix
@@ -117,7 +117,7 @@ quasar: utils: _upstream: hyprland: hyprscroller: pack:
       // {
         inherit config lib;
       }
-    ) utils pkgs.wlr-randr;
+    ) utils "${pkgs.wlr-randr}/bin/wlr-randr";
   };
 
   # All services

--- a/modules/docked.nix
+++ b/modules/docked.nix
@@ -1,12 +1,3 @@
 wlr-randr: screen_off: sleep: {
-  script = ''
-    hdmi_present=$(${wlr-randr} | grep -q "HDMI" && echo true || echo false)
-    if [ "$hdmi_present" = "true" ]; then
-      # HDMI is connected, perform actions for docked mode (only turn off screen)
-      ${screen_off}
-    else
-      # HDMI is not connected, perform actions for undocked mode
-      ${sleep}
-    fi
-  '';
+  script = ''hdmi_present=$(${wlr-randr} | grep -q "HDMI" && echo true || echo false); if [ "$hdmi_present" = "true" ]; then ${screen_off}; else ${sleep}; fi;'';
 }

--- a/modules/docked.nix
+++ b/modules/docked.nix
@@ -1,0 +1,12 @@
+wlr-randr: screen_off: sleep: {
+  script = ''
+    hdmi_present=$(${wlr-randr} | grep -q "HDMI" && echo true || echo false)
+    if [ "$hdmi_present" = "true" ]; then
+      # HDMI is connected, perform actions for docked mode (only turn off screen)
+      ${screen_off}
+    else
+      # HDMI is not connected, perform actions for undocked mode
+      ${sleep}
+    fi
+  '';
+}

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -152,6 +152,16 @@ in
     "$mod, X, resizewindow"
   ];
 
+  # Switches (turn off laptop screen on lid close)
+  bindl = [
+    ", switch:on:Lid Switch, exec, hyprctl keyword monitor \"${
+      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+    }, disable\""
+    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
+      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+    }, enable\""
+  ];
+
   # Window rules
   layerrule = [ ];
   windowrulev2 = [

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -1,4 +1,4 @@
-quasar: utils:
+quasar: utils: wlr:
 let
   inherit (quasar) hyprland;
   hypr = attr: fallback: utils.default hyprland attr fallback;
@@ -153,14 +153,19 @@ in
   ];
 
   # Switches (turn off laptop screen on lid close)
-  bindl = [
-    ", switch:on:Lid Switch, exec, hyprctl keyword monitor \"${
-      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
-    }, disable\""
-    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
-      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
-    }, preferred, auto, 1\"; hyprctl reload;"
-  ];
+  bindl =
+    let
+      screen_off = "hyprctl keyword monitor \"${
+        builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+      }, disable\"";
+      sleep = "systemctl suspend";
+    in
+    [
+      ", switch:on:Lid Switch, exec, ${(import ./docked.nix wlr screen_off sleep).script}"
+      ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
+        builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+      }, preferred, auto, 1\"; hyprctl reload;"
+    ];
 
   # Window rules
   layerrule = [ ];

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -157,9 +157,7 @@ in
     ", switch:on:Lid Switch, exec, hyprctl keyword monitor \"${
       builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
     }, disable\""
-    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
-      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
-    }, enable\""
+    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${builtins.elemAt hyprland.monitors 0}\""
   ];
 
   # Window rules

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -159,7 +159,7 @@ in
     }, disable\""
     ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
       builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
-    }, preferred, auto, 1\""
+    }, preferred, auto, 1\"; hyprctl reload;"
   ];
 
   # Window rules

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -157,7 +157,9 @@ in
     ", switch:on:Lid Switch, exec, hyprctl keyword monitor \"${
       builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
     }, disable\""
-    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${builtins.elemAt hyprland.monitors 0}\""
+    ", switch:off:Lid Switch, exec, hyprctl keyword monitor \"${
+      builtins.elemAt (builtins.split "," (builtins.elemAt hyprland.monitors 0)) 0
+    }, preferred, auto, 1\""
   ];
 
   # Window rules


### PR DESCRIPTION
replace `logind` built-in settings with custom adapter script to check if laptop is docked and engage the appropriate power-saving features